### PR TITLE
Missing dependencies within some components

### DIFF
--- a/data/dependencies/Zend_EventManager.php
+++ b/data/dependencies/Zend_EventManager.php
@@ -1,4 +1,8 @@
 <?php return array (
+  'required' => 
+  array (
+    'Zend_Stdlib',
+  ),
   'optional' => 
   array (
   ),

--- a/data/dependencies/Zend_Loader.php
+++ b/data/dependencies/Zend_Loader.php
@@ -1,5 +1,6 @@
 <?php return array (
   'optional' => 
   array (
+    'Zend_Stdlib',
   ),
 );


### PR DESCRIPTION
The scan tool doesn't parse some dependencies imported by "use" operator. Two test cases:
- EventManager
- Loader
