### PR TITLE
Fixes missing components data (and dependencies)

### DIFF
--- a/data/dependencies/Zend_Mvc.php
+++ b/data/dependencies/Zend_Mvc.php
@@ -1,0 +1,12 @@
+<?php return array (
+  'optional' => 
+  array (
+    'Zend_Di',
+    'Zend_EventManager',
+    'Zend_Loader',
+    'Zend_Http',
+    'Zend_Module',
+    'Zend_Uri',
+    'Zend_Stdlib',
+  ),
+);

--- a/data/dependencies/Zend_View.php
+++ b/data/dependencies/Zend_View.php
@@ -1,0 +1,11 @@
+<?php return array (
+  'required' => 
+  array (
+    'Zend_Loader',
+    'Zend_Stdlib',
+  ),
+  'optional' => 
+  array (
+    'Zend_Filter',
+  ),
+);


### PR DESCRIPTION
The scan tool doesn't include some components with (hard) dependencies. Two test cases:
- Mvc
- View (without helpers)

Warning, some dependencies of MVC components must be hard I guess.
