### PR TITLE
remove ZF2 wiki link. It is dead.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1729,7 +1729,6 @@
             <ul>
                 <li><a href="http://framework.zend.com/">ZF2 Website</a></li>
                 <li><a href="http://framework.zend.com/archives">ZF Mailing List Information</a></li>
-                <li><a href="http://framework.zend.com/wiki/display/ZFDEV2/Home">ZF2 Wiki</a></li>
                 <li><a href="http://framework.zend.com/blog/">Zend Framework Blog</a></li>
                 <li><a href="http://modules.zendframework.com/">ZF2 Modules</a></li>
             </ul>


### PR DESCRIPTION
and currently ZF developers no longer use any wiki system ..
